### PR TITLE
fix packet

### DIFF
--- a/src/client/protocolcodes.h
+++ b/src/client/protocolcodes.h
@@ -117,6 +117,7 @@ namespace Proto
         GameServerMissleEffect = 133, // Anthem on 13.x
         GameServerItemClasses = 134,
         GameServerTrappers = 135,
+        GameServerCloseForgeWindow = 137,
         GameServerCreatureData = 139,
         GameServerCreatureHealth = 140,
         GameServerCreatureLight = 141,

--- a/src/client/protocolgame.h
+++ b/src/client/protocolgame.h
@@ -215,6 +215,7 @@ private:
     void parseContainerRemoveItem(const InputMessagePtr& msg);
     void parseBosstiaryInfo(const InputMessagePtr& msg);
     void parseTakeScreenshot(const InputMessagePtr& msg);
+    void parseCloseForgeWindow(const InputMessagePtr& msg);
     void parseCyclopediaItemDetail(const InputMessagePtr& msg);
     void parseAddInventoryItem(const InputMessagePtr& msg);
     void parseRemoveInventoryItem(const InputMessagePtr& msg);

--- a/src/client/protocolgameparse.cpp
+++ b/src/client/protocolgameparse.cpp
@@ -267,6 +267,9 @@ void ProtocolGame::parseMessage(const InputMessagePtr& msg)
                 case Proto::GameServerTrappers:
                     parseTrappers(msg);
                     break;
+                case Proto::GameServerCloseForgeWindow:
+                    parseCloseForgeWindow(msg);
+                    break;
                 case Proto::GameServerCreatureData:
                     parseCreatureData(msg);
                     break;
@@ -1839,6 +1842,11 @@ void ProtocolGame::addCreatureIcon(const InputMessagePtr& msg)
     }
 
     // TODO: implement creature icons usage
+}
+
+void ProtocolGame::parseCloseForgeWindow(const InputMessagePtr& msg)
+{
+    g_lua.callGlobalField("g_game", "onCloseForgeWindow"); // TODO: implement 
 }
 
 void ProtocolGame::parseCreatureData(const InputMessagePtr& msg)


### PR DESCRIPTION
# Description


i don't know if the error is in canary or otc. but for some reason 

server sent  0x89 to client.
```
void ProtocolGame::closeForgeWindow() {
	NetworkMessage msg;
	msg.addByte(0x89);
	writeToOutputBuffer(msg);
}

```
![vavav](https://github.com/user-attachments/assets/ea4cf02c-8853-4322-995a-7f3f17d99f63)

